### PR TITLE
Update logo.js

### DIFF
--- a/js/logo.js
+++ b/js/logo.js
@@ -9,5 +9,5 @@ app.controller('prmLogoAfterController', [function () {
 app.component('prmLogoAfter', {
   bindings: { parentCtrl: '<' },
   controller: 'prmLogoAfterController',
-  template: '<div class="product-logo product-logo-local" layout="row" layout-align="start center" layout-fill id="banner" tabindex="0" role="banner">\n  <a href="https://www.bu.edu/library/search">\n  <img class="logo-image" alt="{{::(\'nui.header.LogoAlt\' | translate)}}" ng-src="{{$ctrl.getIconLink()}}"/>\n  </a>\n  </div>'
+  template: '<div class="product-logo product-logo-local" layout="row" layout-align="start center" layout-fill id="banner" tabindex="0" role="banner">\n  <a href="https://www.bu.edu/library/search">\n  <img class="logo-image" alt="{{(\'nui.header.LogoAlt\' | translate)}}" ng-src="{{$ctrl.getIconLink()}}"/>\n  </a>\n  </div>'
 });


### PR DESCRIPTION
Correct error, without '::' this part work. Its a error in the original documentation.
At the Moment in your Primo webside it looks `<img class="logo-image" alt="nui.header.LogoAlt" ng-src="custom/BU/img/library-logo.png" src="custom/BU/img/library-logo.png">` so the 'alt' is not ok. After the correction you will have the text you can change in search in Primo BO AdvancedConfiguration / All Code Tables / search for nui.header