### PR TITLE
WEB-138: add stackmap.js to BULAW view

### DIFF
--- a/custom/BULAW/js/BULAW.js
+++ b/custom/BULAW/js/BULAW.js
@@ -1,7 +1,3 @@
-(function(){
-"use strict";
-'use strict';
-
 /*
 * load custom view
 */
@@ -10,4 +6,3 @@ var app = angular.module('viewCustom', ['angularLoad']);
 var lcjs = document.createElement('script');
 lcjs.src = "https://v2.libanswers.com/load_chat.php?hash=d27ec78ed69c9d8969cd01f69fc196f1";
 document.head.appendChild(lcjs);
-})();

--- a/custom/BULAW/js/stackmap.js
+++ b/custom/BULAW/js/stackmap.js
@@ -1,0 +1,25 @@
+// - StackMap: Start - //
+
+/* add fontawesome and stackmap stylesheets to <head> */
+var a = document.querySelector("head");
+var css1 = document.createElement("link"); 
+css1.type = "text/css";
+css1.rel = "Stylesheet";
+css1.href = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css";
+css1.crossorigin = "anonymous";
+a.appendChild(css1); // <link type="text/css" rel="Stylesheet" href="___" crossorigin="anonymous" />
+
+var css2 = document.createElement("link"); 
+css2.type = "text/css";
+css2.rel = "Stylesheet";
+css2.href = "https://www.stackmap.com/integration/bulaw-new-primo/StackMap.css";
+a.appendChild(css2); // <link type="text/css" rel="Stylesheet" href="___" />
+
+/* add stackmap script to <body> */
+var w = document.createElement("script"); 
+w.type = "text/javascript"; w.async = true;
+w.src = "https://www.stackmap.com/integration/bulaw-new-primo/StackMap.js";
+var b = document.body;
+b.appendChild(w);  // <script type="text/javascript" src="___/StackMap.js" async></script>
+
+// - StackMap: END - //


### PR DESCRIPTION
Jira Ticket: [WEB-138](https://bulibrary.atlassian.net/browse/WEB-138)

### Background
- BULAW purchased and configured StackMaps 
- StackMaps provides some [sample code](https://github.com/stackmap/stackmap-integration/blob/master/newprimo/bulaw) for this

### Screenshots
results list
![results list map it button](https://user-images.githubusercontent.com/5565284/59366104-bb68b600-8d07-11e9-9ba9-5797803b3cd0.png)

full display 
![full display map it button](https://user-images.githubusercontent.com/5565284/59366138-cf141c80-8d07-11e9-8a56-5efc9a48bee7.png)


### Description of Changes
imperatively, do the following:
- add the following lines to the `<head>`
```html
<link type="text/css" rel="Stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous" />
<link type="text/css" rel="Stylesheet" href="https://www.stackmap.com/integration/bulaw-new-primo/StackMap.css" />
```
- add `StackMap.js` to the `<body>`
```html
<script type="text/javascript" src="https://www.stackmap.com/integration/bulaw-new-primo/StackMap.js" async></script>
```