### PR TITLE
WEB-336: add 'primo-explore-hathitrust-availability' to BU view

### DIFF
--- a/custom/BU/js/load-helpers.js
+++ b/custom/BU/js/load-helpers.js
@@ -10,6 +10,7 @@ const INCLUDE_EZPROXY = true;
 const INCLUDE_UNPAYWALL = true;
 const INCLUDE_OUTBOUND_LINKS = false;
 const INCLUDE_HELP_MENU = true;
+const INCLUDE_HATHITRUST = true;
 
 // - production vs staging - //
 export const ENV_PRODUCTION = true; 
@@ -30,5 +31,6 @@ if(INCLUDE_EZPROXY){
 // - module dependencies - //
 export let module_dependencies = ['angularLoad', 'noResults'];
 if(INCLUDE_UNPAYWALL){ module_dependencies.push('bulibUnpaywall'); }
+if(INCLUDE_HATHITRUST){ module_dependencies.push('hathiTrustAvailability'); }
 if(INCLUDE_OUTBOUND_LINKS){ module_dependencies.push('outboundLinksLogger'); }
 if(INCLUDE_HELP_MENU){ module_dependencies.push('helpMenuContentDisplay',  'helpMenuTopbar'); }

--- a/custom/BU/js/main.js
+++ b/custom/BU/js/main.js
@@ -13,6 +13,7 @@ if(INCLUDE_GOOGLE_ANALYTICS){
 }
 
 // import npm packages
+import 'primo-explore-hathitrust-availability';
 import 'primo-explore-help-menu';
 import 'primo-explore-outbound-links';
 import 'primo-explore-unpaywall';
@@ -103,7 +104,10 @@ angular.module('viewCustom', module_dependencies)
   
   // configure unpaywallConfig || primoExploreUnpaywallStudioConfig
   .component('prmSearchResultAvailabilityLineAfter', {
-    template: '<bulib-unpaywall></bulib-unpaywall>'
+    template: `
+      <bulib-unpaywall></bulib-unpaywall>
+      <hathi-trust-availability ignore-copyright="true"></hathi-trust-availability>
+    `
   })
   .constant('unpaywallConfig', {
     "email":"aidans@bu.edu",

--- a/custom/BU/js/main.js
+++ b/custom/BU/js/main.js
@@ -102,13 +102,15 @@ angular.module('viewCustom', module_dependencies)
   // configure outboundLinksConfig
   .constant('outboundLinksConfig', default_config)
   
-  // configure unpaywallConfig || primoExploreUnpaywallStudioConfig
+  // add bulib-unpaywall and hathi-trust-availability to result list/full display 
   .component('prmSearchResultAvailabilityLineAfter', {
     template: `
       <bulib-unpaywall></bulib-unpaywall>
-      <hathi-trust-availability ignore-copyright="true"></hathi-trust-availability>
+      <hathi-trust-availability ignore-copyright="true" hide-if-journal="true"></hathi-trust-availability>
     `
   })
+
+  // configure unpaywallConfig || primoExploreUnpaywallStudioConfig
   .constant('unpaywallConfig', {
     "email":"aidans@bu.edu",
     "logToConsole":!ENV_PRODUCTION,

--- a/custom/BU/package.json
+++ b/custom/BU/package.json
@@ -2,6 +2,7 @@
   "name": "BU",
   "description": "default view for http://bu.edu/library running in production since January 2017",
   "devDependencies": {
+    "primo-explore-hathitrust-availability": "^2.4.0",
     "primo-explore-help-menu": "^1.4.1",
     "primo-explore-outbound-links": "^0.6.0",
     "primo-explore-report-problem": "^3.0.0",

--- a/custom/BU/package.json
+++ b/custom/BU/package.json
@@ -2,7 +2,7 @@
   "name": "BU",
   "description": "default view for http://bu.edu/library running in production since January 2017",
   "devDependencies": {
-    "primo-explore-hathitrust-availability": "^2.4.0",
+    "primo-explore-hathitrust-availability": "^2.6.0",
     "primo-explore-help-menu": "^1.4.1",
     "primo-explore-outbound-links": "^0.6.0",
     "primo-explore-report-problem": "^3.0.0",

--- a/custom/CENTRAL_PACKAGE/css/searchBar.css
+++ b/custom/CENTRAL_PACKAGE/css/searchBar.css
@@ -153,3 +153,6 @@ prm-browse-search-bar .clear-button { position: inherit; }
 
 /* WEB-272: announcement banners */  
 prm-search-bar-after, div#bulib-announcements { display: inline-block; }
+
+/* WEB-336 : vertically center the 'Full Text Available at HathiTrust' link */
+.umnHathiTrustLink a { vertical-align: sub; padding-left: var(--padding-small, 5px); }

--- a/custom/CENTRAL_PACKAGE/js/main.js
+++ b/custom/CENTRAL_PACKAGE/js/main.js
@@ -2,10 +2,10 @@ import {addScriptToHead, addStyleToHead} from './header-imports';
 
 // load web components
 addScriptToHead("https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.1.3/webcomponents-loader.min.js", "", "defer");
-addScriptToHead("https://unpkg.com/bulib-wc@0.1.28/src/index.js?module", "module", "defer");
+addScriptToHead("https://unpkg.com/bulib-wc@0.1.31/src/index.js?module", "module", "defer");
 
 // add styles 
-addStyleToHead("https://cdn.jsdelivr.net/npm/bulib-wc@0.1.28/dist/bundle.min.css");
+addStyleToHead("https://cdn.jsdelivr.net/npm/bulib-wc@0.1.31/dist/bundle.min.css");
 
 // create the 'centralCustom' and add in the pageview i
 angular.module('centralCustom', ['angularLoad']);


### PR DESCRIPTION
Jira Ticket: [WEB-336](https://bulibrary.atlassian.net/browse/WEB-336)

### Background
- UMNLibraries has created a package to add a hathitrust availability link to the `prmSearchResultAvailabilityLineAfter`
- we use an existing `primo-explore-unpaywall` package that already uses that 

### Description of Changes
- [x] npm install `primo-explore-hathitrust-availability` and its dependencies/module
- [x] add the `<hathi-trust-availability>` usage next to `<bulib-unpaywall>` in the `prmSearchResultAvailabilityLineAfter`
- [x] use `ignore-copyright` and the `hide-if-journal` attributes (from the newer version) 

### Screenshots
![hathitrust-availability on a book](https://user-images.githubusercontent.com/5565284/79252539-ccb2af80-7e4f-11ea-877d-da4666e0399b.png)
